### PR TITLE
Fix broken resource GUID references (Bandit loadouts, Seward radio)

### DIFF
--- a/7Cav Maps/7CavFactionManager.et
+++ b/7Cav Maps/7CavFactionManager.et
@@ -13,12 +13,12 @@ SCR_LoadoutManager : "{B54D08AEA74A5354}Prefabs/MP/Managers/Loadouts/LoadoutMana
   }
   SCR_FactionPlayerLoadout "{5596D844009597AC}" {
    m_sLoadoutName "Automatic Rifleman"
-   m_sLoadoutResource "{F4699F1320BE6021}Prefabs/Characters/Cav_Factions/Charlie/Charlie_AutomaticRifleman.et"
+   m_sLoadoutResource "{F4699F1320BE6023}Prefabs/Characters/Cav_Factions/Charlie/Charlie_AutomaticRifleman.et"
    m_sAffiliatedFaction "Bandit"
   }
   SCR_PlayerArsenalLoadout "{568CC9D1BC0FCCF3}" {
    m_sLoadoutName "Grenadier"
-   m_sLoadoutResource "{F4EBE02AB4227BD0}Prefabs/Characters/Cav_Factions/Charlie/Charlie_Grenadier.et"
+   m_sLoadoutResource "{F4EBE02AB4227BD2}Prefabs/Characters/Cav_Factions/Charlie/Charlie_Grenadier.et"
    m_sAffiliatedFaction "Bandit"
   }
   SCR_PlayerArsenalLoadout "{568CC9D1B0926B78}" {
@@ -33,7 +33,7 @@ SCR_LoadoutManager : "{B54D08AEA74A5354}Prefabs/MP/Managers/Loadouts/LoadoutMana
   }
   SCR_FactionPlayerLoadout "{607AA5C7CC976D12}" {
    m_sLoadoutName "MAAWS Gunner"
-   m_sLoadoutResource "{6077F964A500E305}Prefabs/Characters/Cav_Factions/Charlie/Charlie_MAAWS.et"
+   m_sLoadoutResource "{6077F964A500E307}Prefabs/Characters/Cav_Factions/Charlie/Charlie_MAAWS.et"
    m_sAffiliatedFaction "Bandit"
   }
   SCR_FactionPlayerLoadout "{61069306CE3712F4}" {

--- a/7Cav Maps/Worlds/7Cav_SB_Seward_Layers/default.layer
+++ b/7Cav Maps/Worlds/7Cav_SB_Seward_Layers/default.layer
@@ -514,7 +514,7 @@ SCR_GameModeEditor GameMode_Editor_Full : "{DA3986AF1B5032B7}Prefabs/MP/Modes/Ed
         SCR_EntityCatalogMultiListEntry "{5C68AD59F0753ABE}" {
          m_aEntities {
           SCR_EntityCatalogInventoryItem "{5C62F7D8F3ED7EFC}" {
-           m_sEntityPrefab "{D69684663E89D6EA}Prefabs/Items/Equipment/Radios/Radio_ANPRC152A_OLD.et"
+           m_sEntityPrefab "{D69684663E89D6EC}Prefabs/Items/Equipment/Radios/Radio_ANPRC152A_OLD.et"
           }
           SCR_EntityCatalogInventoryItem "{657D02E1A3323B64}" {
            m_sEntityPrefab "{C55821E8E86C074E}Prefabs/Items/Equipment/Radios/Radio_ANPRC152.et"


### PR DESCRIPTION
`7CavFactionManager.et` references three Charlie prefabs by GUIDs that no longer exist anywhere in the repo. Each is off by 2 from the GUID of the prefab currently on disk, so the prefabs were evidently deleted and re-created at some point. Enfusion resolves references by GUID, not path, which leaves the Bandit faction's Automatic Rifleman, Grenadier and MAAWS Gunner loadouts pointing at missing resources.

The `Radio_ANPRC152A_OLD` arsenal entry in `7Cav_SB_Seward_Layers/default.layer` has the same problem.

| Reference | Old (dead) GUID | New GUID (file on disk) |
|---|---|---|
| Charlie_AutomaticRifleman.et | F4699F1320BE6021 | F4699F1320BE6023 |
| Charlie_Grenadier.et | F4EBE02AB4227BD0 | F4EBE02AB4227BD2 |
| Charlie_MAAWS.et | 6077F964A500E305 | 6077F964A500E307 |
| Radio_ANPRC152A_OLD.et | D69684663E89D6EA | D69684663E89D6EC |

Testing: open 7Cav Maps in Workbench and confirm the four references show no missing-resource icon; in game, confirm the three Bandit loadouts are selectable again.
