### PR TITLE
Keep the 4x fuel consumption override without redeclaring the vanilla static

### DIFF
--- a/7Cav Systems/scripts/Game/SCR_FuelConsumptionComponent.c
+++ b/7Cav Systems/scripts/Game/SCR_FuelConsumptionComponent.c
@@ -1,13 +1,15 @@
 [BaseContainerProps()]
 modded class SCR_FuelConsumptionComponent
 {
-    static float s_fGlobalFuelConsumptionScale = 4.0;
+    // Do not redeclare s_fGlobalFuelConsumptionScale here: the vanilla class already
+    // declares that static (protected, default 8), so a modded redeclaration conflicts.
+    static const float CAV_GLOBAL_FUEL_CONSUMPTION_SCALE = 4.0;
 
     override void OnPostInit(IEntity owner)
     {
         super.OnPostInit(owner);
 
         if (Replication.IsServer())
-            SetGlobalFuelConsumptionScale(s_fGlobalFuelConsumptionScale);
+            SetGlobalFuelConsumptionScale(CAV_GLOBAL_FUEL_CONSUMPTION_SCALE);
     }
 }


### PR DESCRIPTION
The 4x global fuel consumption scale is intentional (vanilla's 8x default is the thing being corrected). This PR does not change that behavior. The problem is only how it was written: the modded class declared `static float s_fGlobalFuelConsumptionScale = 4.0;`, and vanilla `SCR_FuelConsumptionComponent` already declares that exact static (protected, default 8). A modded class cannot redeclare an existing member, so this is either a compile failure or a shadow variable depending on engine version, and it is fragile against game updates either way.

Changed to a distinctly named constant, still passed to `SetGlobalFuelConsumptionScale()` on the server in `OnPostInit`. Net effect in game is identical: 4x consumption.

Note for later: because this runs in `OnPostInit` of every fuel consumer, any scale an admin changes mid-session gets reset to 4x when the next vehicle spawns. If admin control matters, the call could move to a game-mode init hook instead. Left as-is here to keep the change minimal.
