### PR TITLE
Spawn the belt-link action helper on the server only

### DIFF
--- a/7Cav Systems/scripts/Game/Components/BL_BeltLinkWeaponComponent.c
+++ b/7Cav Systems/scripts/Game/Components/BL_BeltLinkWeaponComponent.c
@@ -19,6 +19,14 @@ class BL_BeltLinkWeaponComponent: ScriptComponent
 	override void OnPostInit(IEntity owner)
 	{
 		super.OnPostInit(owner);
+
+		// The helper prefab carries an RplComponent, so it must only be spawned by
+		// the authority; clients receive it through replication. Spawning it on
+		// every machine gave clients a second, local-only helper whose "Link belt"
+		// action could never reach the server.
+		if (!Replication.IsServer())
+			return;
+
 		SpawnActionHelper();
 	}
 
@@ -55,7 +63,7 @@ class BL_BeltLinkWeaponComponent: ScriptComponent
 		localMat[3] = m_vActionPosition;
 
 		Resource prefab = Resource.Load(m_sActionHelperPrefab);
-		if (!prefab.IsValid())
+		if (!prefab || !prefab.IsValid())
 			return;
 
 		IEntity spawned = GetGame().SpawnEntityPrefab(prefab, weaponEntity.GetWorld(), params);


### PR DESCRIPTION
`BL_BeltLinkWeaponComponent.OnPostInit` spawned the Link Belt action helper on every machine. The helper prefab carries an `RplComponent`, so the server's helper already replicates to every client. Each client therefore ended up with two overlapping helpers:

- the replicated one, whose Link Belt action works (`PerformAction` is server-guarded and routes through the action broadcast), and
- a local-only duplicate whose action can never reach the server and silently does nothing.

Clients still get the helper after this change; they just get it once, through replication, instead of twice. This removes the doubled "Link belt" prompt where one entry was dead.

Also guards the `Resource.Load()` result against null when the helper prefab attribute is left empty.

Please verify in MP before merging: helper position on vehicle-mounted weapons (M2 CROWS) on clients, since the client-side copy previously came from the local spawn.
