### PR TITLE
Fix repeating-timer leak in parachute delete polling

### DIFF
--- a/7Cav Systems/scripts/Game/Parachutes/ParachuteComponentExtended.c
+++ b/7Cav Systems/scripts/Game/Parachutes/ParachuteComponentExtended.c
@@ -330,10 +330,12 @@ class ParachuteComponentExtended : ParachuteComponent
 			return;
 		}
 
+		// One-shot reschedule: the retryCount argument advances the loop. A repeating
+		// CallLater here would pile up timers that fire forever with a stale retryCount.
 		GetGame().GetCallqueue().CallLater(
 			PollUntilEmptyThenDeleteChute,
 			PARACHUTE_DELETE_POLL_INTERVAL_MS,
-			true,
+			false,
 			chute,
 			retryCount + 1,
 			clearState);
@@ -357,7 +359,7 @@ class ParachuteComponentExtended : ParachuteComponent
 			GetGame().GetCallqueue().CallLater(
 				PollUntilEmptyThenDeleteChute,
 				PARACHUTE_DELETE_POLL_INTERVAL_MS,
-				true,
+				false,
 				chute,
 				0,
 				clearState);


### PR DESCRIPTION
`ScheduleChuteDeleteWithPolling` and `PollUntilEmptyThenDeleteChute` pass `repeat = true` to `CallLater` while also manually rescheduling the poll with `retryCount + 1`. Every parachute exit therefore registers a repeating 200 ms timer that is never removed, and each poll iteration registers another one. The repeating instances fire with a stale retryCount, so they never hit the max-retries exit and keep invoking the poll for the rest of the server session. Timer count grows with every jump.

Practical effect: gradually increasing script load and degrading server performance over mission time, worst during and after airborne operations with many jumpers.

The retryCount design is a one-shot rescheduling loop, so this passes `repeat = false` in both places. Poll cadence (200 ms), retry cap (20), and delete behavior are unchanged.

Testing suggestion: on a test server, run 20 or more parachute jumps, then compare script profiler / frame time against current main. On main the poll function keeps firing after all chutes are gone; with this fix it stops.
