### PR TITLE
Replace Charlie's Crye multicam with RHS G3 MCAM, add AVS carriers and FILBE rucks

### DIFF
--- a/7Cav Factions/Configs/Factions/Charlie/Catalogs/Items_EntityCatalog_Charlie.conf
+++ b/7Cav Factions/Configs/Factions/Charlie/Catalogs/Items_EntityCatalog_Charlie.conf
@@ -1978,6 +1978,33 @@ SCR_EntityCatalogMultiList {
   SCR_EntityCatalogMultiListEntry "{664967E60D93647E}" {
    m_sIdentifier "Backpacks and Vests"
    m_aEntities {
+    SCR_EntityCatalogEntry "{6A439C800000003F}" {
+     m_sEntityPrefab "{48602F57998AB597}Prefabs/Items/Equipment/Backpacks/FILBE_Backpack.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C8000000040}" {
+       m_eItemType BACKPACK
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C8000000041}" {
+     m_sEntityPrefab "{BC4ABD18AF9564D5}Prefabs/Items/Equipment/Backpacks/FILBE_Backpack_Heavy.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C8000000042}" {
+       m_eItemType BACKPACK
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C8000000043}" {
+     m_sEntityPrefab "{9A26D311900C33EE}Prefabs/Items/Equipment/Backpacks/FILBE_hydration_pack.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C8000000044}" {
+       m_eItemType BACKPACK
+       m_iSupplyCost 0
+      }
+     }
+    }
     SCR_EntityCatalogEntry "{6A439C8000000019}" {
      m_sEntityPrefab "{6BEC572D4E71CBED}Prefabs/Characters/Vests/Vest_AVS/Vest_AVS_MC.et"
      m_aEntityDataList {

--- a/7Cav Factions/Configs/Factions/Charlie/Catalogs/Items_EntityCatalog_Charlie.conf
+++ b/7Cav Factions/Configs/Factions/Charlie/Catalogs/Items_EntityCatalog_Charlie.conf
@@ -1978,6 +1978,177 @@ SCR_EntityCatalogMultiList {
   SCR_EntityCatalogMultiListEntry "{664967E60D93647E}" {
    m_sIdentifier "Backpacks and Vests"
    m_aEntities {
+    SCR_EntityCatalogEntry "{6A439C8000000019}" {
+     m_sEntityPrefab "{6BEC572D4E71CBED}Prefabs/Characters/Vests/Vest_AVS/Vest_AVS_MC.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C800000001A}" {
+       m_eItemType VEST_AND_WAIST
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C800000001B}" {
+     m_sEntityPrefab "{B7B6E9431730E4FF}Prefabs/Characters/Vests/Vest_AVS/Vest_AVS_Coy.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C800000001C}" {
+       m_eItemType VEST_AND_WAIST
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C800000001D}" {
+     m_sEntityPrefab "{5764FA49A2006F3B}Prefabs/Characters/Vests/Vest_AVS/Vest_AVS_radio_MC.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C800000001E}" {
+       m_eItemType VEST_AND_WAIST
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C800000001F}" {
+     m_sEntityPrefab "{4E09AE60C57189AF}Prefabs/Characters/Vests/Vest_AVS/Vest_AVS_radio_Coy.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C8000000020}" {
+       m_eItemType VEST_AND_WAIST
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C8000000021}" {
+     m_sEntityPrefab "{6AACC58D09743363}Prefabs/Characters/Vests/Vest_AVS/Variants/Vest_AVS_6x6_MC.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C8000000022}" {
+       m_eItemType VEST_AND_WAIST
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C8000000023}" {
+     m_sEntityPrefab "{B5FEEF292633187B}Prefabs/Characters/Vests/Vest_AVS/Variants/Vest_AVS_okinawa_MC.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C8000000024}" {
+       m_eItemType VEST_AND_WAIST
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C8000000025}" {
+     m_sEntityPrefab "{86503C80B70FE586}Prefabs/Characters/Vests/Vest_AVS/Variants/Vest_AVS_okinawa_MC_6x9.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C8000000026}" {
+       m_eItemType VEST_AND_WAIST
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C8000000027}" {
+     m_sEntityPrefab "{C5300A62C49815FF}Prefabs/Characters/Vests/Vest_AVS/Variants/Vest_AVS_okinawa_Coy.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C8000000028}" {
+       m_eItemType VEST_AND_WAIST
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C8000000029}" {
+     m_sEntityPrefab "{A04314012EE0F737}Prefabs/Characters/Vests/Vest_AVS/Variants/Vest_AVS_okinawa_Coy2.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C800000002A}" {
+       m_eItemType VEST_AND_WAIST
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C800000002B}" {
+     m_sEntityPrefab "{45DF58F82205605C}Prefabs/Characters/Vests/Vest_AVS/Variants/Vest_AVS_okinawa_Coy3.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C800000002C}" {
+       m_eItemType VEST_AND_WAIST
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C800000002D}" {
+     m_sEntityPrefab "{A1F502A90AD57908}Prefabs/Characters/Vests/Vest_AVS/Variants/Vest_AVS_okinawa_Coy_6x6.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C800000002E}" {
+       m_eItemType VEST_AND_WAIST
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C800000002F}" {
+     m_sEntityPrefab "{1995D49E1F650C7C}Prefabs/Characters/Vests/Vest_AVS/Variants/Vest_AVS_okinawa_Coy_6x6_2.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C8000000030}" {
+       m_eItemType VEST_AND_WAIST
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C8000000031}" {
+     m_sEntityPrefab "{FC09986713809B17}Prefabs/Characters/Vests/Vest_AVS/Variants/Vest_AVS_okinawa_Coy_6x6_3.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C8000000032}" {
+       m_eItemType VEST_AND_WAIST
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C8000000033}" {
+     m_sEntityPrefab "{3E010420ECE9FC0D}Prefabs/Characters/Vests/Vest_AVS/Variants/Vest_AVS_okinawa_Coy_6x9.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C8000000034}" {
+       m_eItemType VEST_AND_WAIST
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C8000000035}" {
+     m_sEntityPrefab "{7E2DB938F7348CDC}Prefabs/Characters/Vests/Vest_AVS/Variants/Vest_AVS_okinawa_Coy_6x9_2.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C8000000036}" {
+       m_eItemType VEST_AND_WAIST
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C8000000037}" {
+     m_sEntityPrefab "{9BB1F5C1FBD11BB7}Prefabs/Characters/Vests/Vest_AVS/Variants/Vest_AVS_okinawa_Coy_6x9_3.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C8000000038}" {
+       m_eItemType VEST_AND_WAIST
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C8000000039}" {
+     m_sEntityPrefab "{6AB41609027AA0FB}Prefabs/Characters/Vests/Vest_AVS/Variants/Vest_AVS_okinawa_CoyMG.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C800000003A}" {
+       m_eItemType VEST_AND_WAIST
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C800000003B}" {
+     m_sEntityPrefab "{50F366D098451356}Prefabs/Characters/Vests/Vest_AVS/Variants/Vest_AVS_shaw_Coy.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C800000003C}" {
+       m_eItemType VEST_AND_WAIST
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C800000003D}" {
+     m_sEntityPrefab "{F0FA0DF11A3E941B}Prefabs/Characters/Vests/Vest_AVS/Variants/Vest_AVS_nobelt_Coy.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C800000003E}" {
+       m_eItemType VEST_AND_WAIST
+       m_iSupplyCost 0
+      }
+     }
+    }
     SCR_EntityCatalogEntry "{66497B3064F70D36}" {
      m_sEntityPrefab "{E2F3C74458168302}Prefabs/Characters/HeadGear/Helmet_MICH_ACH/Helmet_ACH_SHROUD_base.et"
      m_aEntityDataList {

--- a/7Cav Factions/Configs/Factions/Charlie/Catalogs/Items_EntityCatalog_Charlie.conf
+++ b/7Cav Factions/Configs/Factions/Charlie/Catalogs/Items_EntityCatalog_Charlie.conf
@@ -2202,6 +2202,114 @@ SCR_EntityCatalogMultiList {
   SCR_EntityCatalogMultiListEntry "{664967E60C3BA59E}" {
    m_sIdentifier "Clothing"
    m_aEntities {
+    SCR_EntityCatalogEntry "{6A439C8000000001}" {
+     m_sEntityPrefab "{F894DB801742C052}Prefabs/Characters/Uniforms/Shirt_CP_G3/CP_G3_Shirt_ColA_BaseT_FullS_MC.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C8000000002}" {
+       m_eItemType TORSO
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C8000000003}" {
+     m_sEntityPrefab "{23428DF912E6E1DF}Prefabs/Characters/Uniforms/Shirt_CP_G3/CP_G3_Shirt_ColA_BaseT_PushS_MC.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C8000000004}" {
+       m_eItemType TORSO
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C8000000005}" {
+     m_sEntityPrefab "{7F453261721CCE10}Prefabs/Characters/Uniforms/Shirt_CP_G3/CP_G3_Shirt_ColA_BaseT_RollS_MC.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C8000000006}" {
+       m_eItemType TORSO
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C8000000007}" {
+     m_sEntityPrefab "{BD397F40B7402C16}Prefabs/Characters/Uniforms/Shirt_CP_G3/CP_G3_Shirt_ColA_OutT_FullS_MC.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C8000000008}" {
+       m_eItemType TORSO
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C8000000009}" {
+     m_sEntityPrefab "{66EF2939B2E40D9B}Prefabs/Characters/Uniforms/Shirt_CP_G3/CP_G3_Shirt_ColA_OutT_PushS_MC.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C800000000A}" {
+       m_eItemType TORSO
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C800000000B}" {
+     m_sEntityPrefab "{3AE896A1D21E2254}Prefabs/Characters/Uniforms/Shirt_CP_G3/CP_G3_Shirt_ColA_OutT_RollS_MC.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C800000000C}" {
+       m_eItemType TORSO
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C800000000D}" {
+     m_sEntityPrefab "{B81D7AF80636D808}Prefabs/Characters/Uniforms/Pants_CP_G3/CP_G3_Pants_base_MC.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C800000000E}" {
+       m_eItemType LEGS
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C800000000F}" {
+     m_sEntityPrefab "{5FB97B757511D4AA}Prefabs/Characters/Uniforms/Pants_CP_G3/CP_G3_Pants_no_kpads_MC.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C8000000010}" {
+       m_eItemType LEGS
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C8000000011}" {
+     m_sEntityPrefab "{BC13AD4C3E6173AF}Prefabs/Characters/Uniforms/Pants_CP_G3/CP_G3_Pants_KpadsG2_MC.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C8000000012}" {
+       m_eItemType LEGS
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C8000000013}" {
+     m_sEntityPrefab "{7BDF3DD1CB3730A3}Prefabs/Characters/Uniforms/Pants_CP_G3/CP_G3_Pants_KpadsG3_MC.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C8000000014}" {
+       m_eItemType LEGS
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C8000000015}" {
+     m_sEntityPrefab "{A9590DD7524094A1}Prefabs/Characters/Uniforms/Pants_CP_G3/CP_G3_Pants_KpadsG4_MC.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C8000000016}" {
+       m_eItemType LEGS
+       m_iSupplyCost 0
+      }
+     }
+    }
+    SCR_EntityCatalogEntry "{6A439C8000000017}" {
+     m_sEntityPrefab "{B4E5DD4F6136609D}Prefabs/Characters/Uniforms/Pants_CP_G3/CP_G3_Pants_KpadsSP_MC.et"
+     m_aEntityDataList {
+      SCR_ArsenalItem "{6A439C8000000018}" {
+       m_eItemType LEGS
+       m_iSupplyCost 0
+      }
+     }
+    }
     SCR_EntityCatalogEntry "{66497B3EE50EF1C6}" {
      m_sEntityPrefab "{2FDEBA2FF1B7759E}Prefabs/Characters/Uniforms/Crye_Pants/crye_pants_mc.et"
      m_aEntityDataList {


### PR DESCRIPTION
## Summary

Replaces Charlie's legacy Crye multicam uniform with the RHS Crye Precision G3 set in MCAM, and adds AVS plate carriers with their pouch presets plus the FILBE rucks.

Everything comes from **RHS: Status Quo** (`595F2BF2F44836FB`), already a declared dependency of 7Cav Factions. **No new dependencies.** One file changed.

Split into three commits so each group can be reviewed or dropped independently.

## Commits

| Commit | Change | List |
| --- | --- | --- |
| Uniforms | **-2 legacy, +5 G3** | `Clothing` |
| AVS | +6 carriers, +13 pouch presets | `Backpacks and Vests` |
| FILBE | +3 rucks | `Backpacks and Vests` |

### Uniforms (replacement)

Removed:

| Prefab | Slot |
| --- | --- |
| `Jacket_Crye_Combat_Shirt_MC.et` | `TORSO` |
| `crye_pants_mc.et` | `LEGS` |

Added:

| Prefab | Cut |
| --- | --- |
| `CP_G3_Shirt_ColA_BaseT_FullS_MC.et` | tucked, sleeves down |
| `CP_G3_Shirt_ColA_BaseT_PushS_MC.et` | tucked, sleeves cuffed |
| `CP_G3_Shirt_ColA_OutT_FullS_MC.et` | untucked, sleeves down |
| `CP_G3_Shirt_ColA_OutT_PushS_MC.et` | untucked, sleeves cuffed |
| `CP_G3_Pants_KpadsG2_MC.et` | G2 knee pads |

Rolled sleeve shirts and the other knee pad variants are intentionally left out.

These are the uniforms worn by the RHS MARSOC multicam characters. `Character_RHS_USMC_MARSOC_MC_TL` and its siblings inherit `CP_G3_Shirt_ColA_BaseT_PushS_MC` and `CP_G3_Pants_KpadsG3_MC` from `Character_RHS_USMC_MARSOC_MC_BaseLoadout`.

### AVS

Charlie previously carried only `Vest_AVS_6x9_MC` and `Vest_AVS_6x9_Coy`. This adds the plain and radio carriers in MC and Coyote, plus the `okinawa`, `shaw`, `6x6` and `6x9` pouch presets. Presets only, no loose `Pouch_AVS_*` items, since no individual pouches are whitelisted anywhere in the repo today.

### FILBE

`FILBE_Backpack` is the ruck carried by the RHS MARSOC multicam characters and was not whitelisted for any faction. `FILBE_Backpack_Heavy` and `FILBE_hydration_pack` come along as the obvious companions.

## Note for reviewers

`CnakedManBase.et`, Charlie's base character prefab, still lists the removed `Jacket_Crye_Combat_Shirt_MC` and `crye_pants_mc` as its spawn loadout. That is untouched here, so troopers still **spawn** in the old Crye multicam and would switch to G3 at an arsenal. Happy to fold the character prefab update into this PR or handle it separately, whichever is preferred.

## Scope

**Charlie only.** Bravo's catalogs (Helios, Pioneer, Viking) are deliberately untouched, as are Alpha and Students, which still carry the legacy Crye multicam.

## Verification

- All 27 prefab GUID and path pairs checked against the `resourceDatabase.rdb` shipped with RHS: Status Quo. Exact matches.
- Only non-`_wear` prefabs are listed. The `*_wear` variants are on-body render meshes, not arsenal items.
- Brace balance intact; no new duplicate entry IDs introduced.
- CRLF line endings preserved.
- Loaded in Workbench: Charlie's catalog resolves through `Charlie_Faction_Base.conf` with zero resource errors on any added entry.
