### PR TITLE
Make G3 MCAM the only multicam uniform for Charlie

### DIFF
--- a/7Cav Factions/Configs/Factions/Charlie/Catalogs/Items_EntityCatalog_Charlie.conf
+++ b/7Cav Factions/Configs/Factions/Charlie/Catalogs/Items_EntityCatalog_Charlie.conf
@@ -2427,15 +2427,6 @@ SCR_EntityCatalogMultiList {
       }
      }
     }
-    SCR_EntityCatalogEntry "{6A439C8000000005}" {
-     m_sEntityPrefab "{7F453261721CCE10}Prefabs/Characters/Uniforms/Shirt_CP_G3/CP_G3_Shirt_ColA_BaseT_RollS_MC.et"
-     m_aEntityDataList {
-      SCR_ArsenalItem "{6A439C8000000006}" {
-       m_eItemType TORSO
-       m_iSupplyCost 0
-      }
-     }
-    }
     SCR_EntityCatalogEntry "{6A439C8000000007}" {
      m_sEntityPrefab "{BD397F40B7402C16}Prefabs/Characters/Uniforms/Shirt_CP_G3/CP_G3_Shirt_ColA_OutT_FullS_MC.et"
      m_aEntityDataList {
@@ -2454,83 +2445,11 @@ SCR_EntityCatalogMultiList {
       }
      }
     }
-    SCR_EntityCatalogEntry "{6A439C800000000B}" {
-     m_sEntityPrefab "{3AE896A1D21E2254}Prefabs/Characters/Uniforms/Shirt_CP_G3/CP_G3_Shirt_ColA_OutT_RollS_MC.et"
-     m_aEntityDataList {
-      SCR_ArsenalItem "{6A439C800000000C}" {
-       m_eItemType TORSO
-       m_iSupplyCost 0
-      }
-     }
-    }
-    SCR_EntityCatalogEntry "{6A439C800000000D}" {
-     m_sEntityPrefab "{B81D7AF80636D808}Prefabs/Characters/Uniforms/Pants_CP_G3/CP_G3_Pants_base_MC.et"
-     m_aEntityDataList {
-      SCR_ArsenalItem "{6A439C800000000E}" {
-       m_eItemType LEGS
-       m_iSupplyCost 0
-      }
-     }
-    }
-    SCR_EntityCatalogEntry "{6A439C800000000F}" {
-     m_sEntityPrefab "{5FB97B757511D4AA}Prefabs/Characters/Uniforms/Pants_CP_G3/CP_G3_Pants_no_kpads_MC.et"
-     m_aEntityDataList {
-      SCR_ArsenalItem "{6A439C8000000010}" {
-       m_eItemType LEGS
-       m_iSupplyCost 0
-      }
-     }
-    }
     SCR_EntityCatalogEntry "{6A439C8000000011}" {
      m_sEntityPrefab "{BC13AD4C3E6173AF}Prefabs/Characters/Uniforms/Pants_CP_G3/CP_G3_Pants_KpadsG2_MC.et"
      m_aEntityDataList {
       SCR_ArsenalItem "{6A439C8000000012}" {
        m_eItemType LEGS
-       m_iSupplyCost 0
-      }
-     }
-    }
-    SCR_EntityCatalogEntry "{6A439C8000000013}" {
-     m_sEntityPrefab "{7BDF3DD1CB3730A3}Prefabs/Characters/Uniforms/Pants_CP_G3/CP_G3_Pants_KpadsG3_MC.et"
-     m_aEntityDataList {
-      SCR_ArsenalItem "{6A439C8000000014}" {
-       m_eItemType LEGS
-       m_iSupplyCost 0
-      }
-     }
-    }
-    SCR_EntityCatalogEntry "{6A439C8000000015}" {
-     m_sEntityPrefab "{A9590DD7524094A1}Prefabs/Characters/Uniforms/Pants_CP_G3/CP_G3_Pants_KpadsG4_MC.et"
-     m_aEntityDataList {
-      SCR_ArsenalItem "{6A439C8000000016}" {
-       m_eItemType LEGS
-       m_iSupplyCost 0
-      }
-     }
-    }
-    SCR_EntityCatalogEntry "{6A439C8000000017}" {
-     m_sEntityPrefab "{B4E5DD4F6136609D}Prefabs/Characters/Uniforms/Pants_CP_G3/CP_G3_Pants_KpadsSP_MC.et"
-     m_aEntityDataList {
-      SCR_ArsenalItem "{6A439C8000000018}" {
-       m_eItemType LEGS
-       m_iSupplyCost 0
-      }
-     }
-    }
-    SCR_EntityCatalogEntry "{66497B3EE50EF1C6}" {
-     m_sEntityPrefab "{2FDEBA2FF1B7759E}Prefabs/Characters/Uniforms/Crye_Pants/crye_pants_mc.et"
-     m_aEntityDataList {
-      SCR_ArsenalItem "{66497B3EE0FE1011}" {
-       m_eItemType LEGS
-       m_iSupplyCost 0
-      }
-     }
-    }
-    SCR_EntityCatalogEntry "{66497B3ECC8626DB}" {
-     m_sEntityPrefab "{7BA7FF3E9F68960E}Prefabs/Characters/Uniforms/Crye_Shirt/Jacket_Crye_Combat_Shirt_MC.et"
-     m_aEntityDataList {
-      SCR_ArsenalItem "{66497B3ECC8625AE}" {
-       m_eItemType TORSO
        m_iSupplyCost 0
       }
      }


### PR DESCRIPTION
## Summary

Follow up to #95. That PR added the RHS Crye G3 MCAM set **alongside** Charlie's existing Crye multicam. This makes the G3 set the **replacement**, and trims it to the cuts actually wanted.

**Removals only.** 81 deletions, 0 additions, one file. The AVS carriers, pouch presets and FILBE rucks from #95 are untouched.

## Removed

Legacy multicam, now superseded:

| Prefab | Slot |
| --- | --- |
| `Jacket_Crye_Combat_Shirt_MC.et` | `TORSO` |
| `crye_pants_mc.et` | `LEGS` |

G3 cuts not wanted:

| Prefab | Why |
| --- | --- |
| `CP_G3_Shirt_ColA_BaseT_RollS_MC.et` | rolled sleeves |
| `CP_G3_Shirt_ColA_OutT_RollS_MC.et` | rolled sleeves |
| `CP_G3_Pants_base_MC.et` | keeping G2 knee pads only |
| `CP_G3_Pants_no_kpads_MC.et` | keeping G2 knee pads only |
| `CP_G3_Pants_KpadsG3_MC.et` | keeping G2 knee pads only |
| `CP_G3_Pants_KpadsG4_MC.et` | keeping G2 knee pads only |
| `CP_G3_Pants_KpadsSP_MC.et` | keeping G2 knee pads only |

## Charlie's Clothing list after this

| Prefab | Cut |
| --- | --- |
| `CP_G3_Shirt_ColA_BaseT_FullS_MC.et` | tucked, sleeves down |
| `CP_G3_Shirt_ColA_BaseT_PushS_MC.et` | tucked, sleeves cuffed |
| `CP_G3_Shirt_ColA_OutT_FullS_MC.et` | untucked, sleeves down |
| `CP_G3_Shirt_ColA_OutT_PushS_MC.et` | untucked, sleeves cuffed |
| `CP_G3_Pants_KpadsG2_MC.et` | G2 knee pads |

Boots, balaclavas, eyewear and patches are unchanged.

## Note for reviewers

`CnakedManBase.et`, Charlie's base character prefab, still lists the removed `Jacket_Crye_Combat_Shirt_MC` and `crye_pants_mc` as its spawn loadout. That is untouched here, so troopers still **spawn** in the old Crye multicam and would switch to G3 at an arsenal. Happy to fold the character prefab update into this PR or handle it separately, whichever is preferred.

## Scope

**Charlie only.** Alpha, Bravo (Helios, Pioneer, Viking) and Students still carry the legacy Crye multicam and are deliberately untouched.

## Verification

- Entry blocks removed whole, by brace-depth tracking. Brace balance intact at 1639/1639.
- No additions, so no new GUIDs or entry IDs to verify.
- CRLF line endings preserved.
- AVS and FILBE sections confirmed unchanged.
