### PR TITLE
Set Charlie's default kit to the RHS G3 MCAM uniform

### DIFF
--- a/7Cav Factions/Prefabs/Characters/Cav_Factions/Charlie/CnakedManBase.et
+++ b/7Cav Factions/Prefabs/Characters/Cav_Factions/Charlie/CnakedManBase.et
@@ -31,10 +31,10 @@ SCR_ChimeraCharacter : "{ECD07832524366A2}Prefabs/Characters/Cav_Factions/Prefab
      Prefab "{4B27F698E10C5C9C}Prefabs/Characters/HeadGear/Helmet_OPSCORE/Helmet_OPSCORE_MID_MC_AMP_CAV.et"
     }
     LoadoutSlotInfo Jacket {
-     Prefab "{7BA7FF3E9F68960E}Prefabs/Characters/Uniforms/Crye_Shirt/Jacket_Crye_Combat_Shirt_MC.et"
+     Prefab "{F894DB801742C052}Prefabs/Characters/Uniforms/Shirt_CP_G3/CP_G3_Shirt_ColA_BaseT_FullS_MC.et"
     }
     LoadoutSlotInfo Pants {
-     Prefab "{2FDEBA2FF1B7759E}Prefabs/Characters/Uniforms/Crye_Pants/crye_pants_mc.et"
+     Prefab "{BC13AD4C3E6173AF}Prefabs/Characters/Uniforms/Pants_CP_G3/CP_G3_Pants_KpadsG2_MC.et"
     }
     LoadoutSlotInfo Boots {
      Prefab "{320FA1CD5B1D5601}Prefabs/Characters/Footwear/Boots_USMC_Combat/Footwear_USMC_Combat.et"
@@ -47,13 +47,13 @@ SCR_ChimeraCharacter : "{ECD07832524366A2}Prefabs/Characters/Cav_Factions/Prefab
   SCR_InventoryStorageManagerComponent "{520EA1D2DB118DE5}" {
    InitialInventoryItems {
     ItemsInitConfigurationItem "{6690081F571D21D8}" {
-     TargetStorage "Pants/crye_pants_mc.et"
+     TargetStorage "Pants/CP_G3_Pants_KpadsG2_MC.et"
      PrefabsToSpawn {
       "{922F95F91943F69A}Prefabs/Items/Equipment/Maps/Map_Paper_01/PaperMap_01_folded_US.et" "{6E35D94130954509}Prefabs/Items/Equipment/Accessories/ETool_ALICE/ETool_ALICE_FreeRoamBuilding_Gadget.et" "{61D4F80E49BF9B12}Prefabs/Items/Equipment/Compass/Compass_SY183.et"
      }
     }
     ItemsInitConfigurationItem "{66900810FC9997AB}" {
-     TargetStorage "Jacket/Jacket_Crye_Combat_Shirt_MC.et"
+     TargetStorage "Jacket/CP_G3_Shirt_ColA_BaseT_FullS_MC.et"
      PrefabsToSpawn {
       "{A81F501D3EF6F38E}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_US_01.et" "{A81F501D3EF6F38E}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_US_01.et" "{A81F501D3EF6F38E}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_US_01.et" "{A81F501D3EF6F38E}Prefabs/Items/Medicine/FieldDressing_01/FieldDressing_US_01.et" "{D70216B1B2889129}Prefabs/Items/Medicine/Tourniquet_01/Tourniquet_US_01.et" "{0D9A5DCF89AE7AA9}Prefabs/Items/Medicine/MorphineInjection_01/MorphineInjection_01.et" "{0D9A5DCF89AE7AA9}Prefabs/Items/Medicine/MorphineInjection_01/MorphineInjection_01.et" "{5B2FD067D70C1E8F}Prefabs/Items/Medicine/EpinephrineInjection/ACE_Medical_EpinephrineInjection.et" "{5B2FD067D70C1E8F}Prefabs/Items/Medicine/EpinephrineInjection/ACE_Medical_EpinephrineInjection.et"
      }


### PR DESCRIPTION
## Summary

Follow up to #95. That PR whitelisted the RHS Crye G3 MCAM set for Charlie's arsenal, but Charlie still **spawned** in the older Crye multicam, so the default kit did not match what the arsenal offers.

**One file, 4 insertions, 4 deletions.** The arsenal whitelist is untouched; all G3 variants stay available.

## Change

`CnakedManBase.et` is the base every Charlie role prefab inherits from, so this is the only file that needs to change.

| Slot | Was | Now |
| --- | --- | --- |
| Jacket | `Jacket_Crye_Combat_Shirt_MC.et` | `CP_G3_Shirt_ColA_BaseT_FullS_MC.et` (tucked, sleeves down) |
| Pants | `crye_pants_mc.et` | `CP_G3_Pants_KpadsG2_MC.et` (G2 knee pads) |

## Why the TargetStorage lines change too

`InitialInventoryItems` keys its entries by `<SlotName>/<PrefabFileName>.et`:

```
TargetStorage "Pants/crye_pants_mc.et"                    -> "Pants/CP_G3_Pants_KpadsG2_MC.et"
TargetStorage "Jacket/Jacket_Crye_Combat_Shirt_MC.et"     -> "Jacket/CP_G3_Shirt_ColA_BaseT_FullS_MC.et"
```

Changing the uniform prefabs without updating these would leave the paper map, entrenching tool, compass, four field dressings, tourniquet, two morphine and two epinephrine unplaced, since the target storage would no longer resolve.

## Verification

- Both new prefab GUID and path pairs checked against the `resourceDatabase.rdb` shipped with RHS: Status Quo. Exact matches.
- Loadout prefab filenames and their `TargetStorage` strings confirmed consistent for both slots.
- No remaining reference to `Jacket_Crye_Combat_Shirt_MC` or `crye_pants_mc` anywhere in the prefab.
- Brace balance intact. CRLF preserved.

## Notes

Shirt cut is a single-line change if a different one is preferred. The non-rolled options are `BaseT_FullS` (tucked, sleeves down, used here), `BaseT_PushS` (tucked, cuffed), `OutT_FullS` (untucked, sleeves down) and `OutT_PushS` (untucked, cuffed). For reference the RHS MARSOC multicam characters wear `BaseT_PushS`.

**Charlie only.** Alpha, Bravo and Students still spawn in the legacy Crye multicam and are deliberately untouched.
